### PR TITLE
TruncatedSVD V1 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ disallow_untyped_defs = false
 disallow_incomplete_defs = false
 check_untyped_defs = true
 strict = false
+disable_error_code = ["import-untyped"]
 
 [tool.ruff]
 src = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,9 @@ disallow_untyped_defs = false
 disallow_incomplete_defs = false
 check_untyped_defs = true
 strict = false
-disable_error_code = ["import-untyped"]
+[[tool.mypy.overrides]]
+module = ["dask_ml.decomposition.*"]
+ignore_missing_imports = true
 
 [tool.ruff]
 src = ["src"]

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -155,7 +155,7 @@ class TruncatedSVD(SVD):
             logger.exception(msg)
             raise RuntimeError(msg)
 
-    def fit(self, n_components: int = 50):
+    def fit(self, n_components: int):
         logger.info("Fitting truncated SVD...")
         decomposer = tsvd(n_components=n_components)
 

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -144,13 +144,44 @@ class ExactSVD(SVD):
 
 
 class TruncatedSVD(SVD):
+    """
+    TruncatedSVD performs truncated Singular Value Decomposition (SVD)
+    on a tall-and-skinny matrix.
+
+    This class supports both tall-and-skinny and short-and-fat matrices,
+    but not square matrices. If the matrix is short-and-fat, it transposes
+    the matrix before fitting the truncated SVD. For square matrices,
+    consider using the randomized SVD algorithm instead.
+
+    Parameters
+    ----------
+    X : dask.array.Array
+        Input matrix to decompose.
+
+    Attributes
+    ----------
+    u : dask.array.Array
+        Left singular vectors.
+    v : dask.array.Array
+        Right singular vectors.
+    s : numpy.ndarray
+        Singular values.
+
+    Methods
+    -------
+    fit(n_components)
+        Compute the truncated SVD of the input matrix, keeping the
+        specified number of components.
+    """
+
     def __init__(self, X):
         super().__init__(X)
         if self.matrix_type == "square":
             msg = (
                 "The truncated SVD algorithm can only handle tall-and-skinny "
                 "or short-and-fat matrices. "
-                "Try using the randomized SVD algorithm instead."
+                "For square/nearly-square matrices, try using the randomized "
+                "SVD algorithm instead."
             )
             logger.exception(msg)
             raise RuntimeError(msg)

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -183,8 +183,6 @@ class TruncatedSVD(SVD):
 
                 u = da.from_array(u_np, chunks=u_np.shape)
 
-            u, s, v = persist(u, s, v)
-
             self.u = u
             self.v = v
             self.s = s  # numpy array

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -149,8 +149,8 @@ class TruncatedSVD(SVD):
         if self.matrix_type == "square":
             msg = (
                 "The truncated SVD algorithm can only handle tall-and-skinny "
-                "or short-and-fat matrices, i.e. the aspect ratio must be "
-                ">= 10. Try using the randomized SVD algorithm instead."
+                "or short-and-fat matrices. "
+                "Try using the randomized SVD algorithm instead."
             )
             logger.exception(msg)
             raise RuntimeError(msg)
@@ -176,7 +176,7 @@ class TruncatedSVD(SVD):
                 X_transformed_t = decomposer.fit_transform(self.X.T)
                 s = decomposer.singular_values_
                 v_t_np = decomposer.components_
-                u_t = X_transformed_t / s
+                u_t = X_transformed_t / s  # unscaled
 
                 u_np = v_t_np.T
                 v = u_t.T

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -186,7 +186,7 @@ class TruncatedSVD(SVD):
             logger.exception(msg)
             raise RuntimeError(msg)
 
-    def fit(self, n_components: int):
+    def fit(self, n_components):
         logger.info("Fitting truncated SVD...")
         decomposer = tsvd(n_components=n_components)
 

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -137,15 +137,15 @@ class TestSVD:
 
             u, s, v = truncated_svd.u, truncated_svd.s, truncated_svd.v
 
-            assert isinstance(u, da.Array), (
-                "The u matrix should be of type dask.array.Array, " f"not {type(u)}."
-            )
-            assert isinstance(s, np.ndarray), (
-                "The s vector should be of type numpy.ndarray, " f"not {type(s)}."
-            )
-            assert isinstance(v, da.Array), (
-                "The v matrix should be of type dask.array.Array, " f"not {type(v)}."
-            )
+            assert isinstance(
+                u, da.Array
+            ), f"The u matrix should be of type dask.array.Array, not {type(u)}."
+            assert isinstance(
+                s, np.ndarray
+            ), f"The s vector should be of type numpy.ndarray, not {type(s)}."
+            assert isinstance(
+                v, da.Array
+            ), f"The v matrix should be of type dask.array.Array, not {type(v)}."
 
             assert u.shape == (n_rows, n_components), (
                 f"The u matrix should have shape ({n_rows}, {n_components}), "

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -97,46 +97,77 @@ class TestSVD:
         assert randomized_svd.u.shape == (
             n_rows,
             n_components,
-        ), "The u matrix should have shape (n_samples, n_components)."
+        ), (
+            f"The u matrix should have shape ({n_rows}, {n_components}), "
+            f"but got {randomized_svd.u.shape}."
+        )
         assert randomized_svd.v.shape == (
             n_components,
             n_cols,
-        ), "The v matrix should have shape (n_components, n_features)."
-        assert randomized_svd.s.shape == (
-            n_components,
-        ), "The s vector should have shape (n_components,)."
+        ), (
+            f"The v matrix should have shape ({n_components}, {n_cols}), "
+            f"but got {randomized_svd.v.shape}."
+        )
+        assert randomized_svd.s.shape == (n_components,), (
+            f"The s vector should have shape ({n_components},), "
+            f"but got {randomized_svd.s.shape}."
+        )
 
     def test_truncated_svd(self, matrix_type, n_rows, n_cols):
+        print(f"Running truncated SVD test for {matrix_type} matrix.")
         self._make_matrix(n_rows, n_cols)
         n_components = 10
 
         if matrix_type == "square":
-            with pytest.raises(
-                RuntimeError, match="truncated SVD algorithm can only handle"
-            ):
+            with pytest.raises(RuntimeError):
                 TruncatedSVD(self.X)
         else:
             truncated_svd = TruncatedSVD(self.X)
             truncated_svd.fit(n_components=n_components)
 
-            assert hasattr(truncated_svd, "u")
-            assert hasattr(truncated_svd, "s")
-            assert hasattr(truncated_svd, "v")
+            assert hasattr(
+                truncated_svd, "u"
+            ), "The truncated_svd object should have attribute 'u'."
+            assert hasattr(
+                truncated_svd, "s"
+            ), "The truncated_svd object should have attribute 's'."
+            assert hasattr(
+                truncated_svd, "v"
+            ), "The truncated_svd object should have attribute 'v'."
 
             u, s, v = truncated_svd.u, truncated_svd.s, truncated_svd.v
 
-            assert isinstance(u, da.Array)
-            assert isinstance(s, np.ndarray)
-            assert isinstance(v, da.Array)
+            assert isinstance(u, da.Array), (
+                "The u matrix should be of type dask.array.Array, " f"not {type(u)}."
+            )
+            assert isinstance(s, np.ndarray), (
+                "The s vector should be of type numpy.ndarray, " f"not {type(s)}."
+            )
+            assert isinstance(v, da.Array), (
+                "The v matrix should be of type dask.array.Array, " f"not {type(v)}."
+            )
 
-            assert u.shape == (n_rows, n_components)
-            assert s.shape == (n_components,)
-            assert v.shape == (n_components, n_cols)
+            assert u.shape == (n_rows, n_components), (
+                f"The u matrix should have shape ({n_rows}, {n_components}), "
+                f"but got {u.shape}."
+            )
+            assert s.shape == (n_components,), (
+                f"The s vector should have shape ({n_components},), "
+                f"but got {s.shape}."
+            )
+            assert v.shape == (n_components, n_cols), (
+                f"The v matrix should have shape ({n_components}, {n_cols}), "
+                f"but got {v.shape}."
+            )
 
-            # check ortho
+            # check orthogonality
             identity_k = np.eye(n_components, dtype=np.float32)
             u_ortho = (u.T @ u).compute()
             v_ortho = (v @ v.T).compute()
 
-            assert np.allclose(u_ortho, identity_k, atol=1e-5)
-            assert np.allclose(v_ortho, identity_k, atol=1e-5)
+            assert np.allclose(
+                u_ortho, identity_k, atol=1e-5
+            ), "u.T @ u is not close to identity."
+            assert np.allclose(
+                v_ortho, identity_k, atol=1e-5
+            ), "v @ v.T is not close to identity."


### PR DESCRIPTION
Implemented TruncatedSVD + tests. 

Implemented: The TruncatedSVD only calculates the top `k` singular components. 

- For tall-and-skinny matrices, it calls fit_transform directly.
- For short-and-fat matrices, it computes the SVD on the transpose of the data (X.T) and then mathematically transforms the results back to get the SVD of the original matrix X.

Added: a new parameterized test, `test_truncated_svd` 

The test is mostly the same as the exact svd one, but it also verifies the mathematical correctness of the decomposition by computing u.T @ u and v @ v.T and comparing it to an identity matrix.

Added: ignore missing imports for `dask_ml.decomposition` in `pyproject.toml`.  