### PR TITLE
Incorporate transform method in SVD classes

### DIFF
--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -132,6 +132,12 @@ class ExactSVD(SVD):
         keep all SVD components. For additional keyword arguments,
         see the documentation for `dask.array.linalg.svd`.
         """
+        if n_components != -1 and (
+            not isinstance(n_components, int) or n_components <= 0
+        ):
+            msg = "n_components must be -1 or a positive integer."
+            logger.exception(msg)
+            raise ValueError(msg)
         self.n_components = n_components
         self.X = self.X.persist()
         try:

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -318,3 +318,18 @@ class RandomizedSVD(SVD):
             msg = "Failed fitting randomized SVD."
             logger.exception(msg)
             raise RuntimeError(msg) from e
+
+    def transform(self):
+        if self.n_components == 0:
+            msg = "You have to call `fit` before you can call `transform`."
+            logger.exception(msg)
+            raise RuntimeError(msg)
+        try:
+            if self.matrix_type == "tall-and-skinny" or self.matrix_type == "square":
+                self.u = self.u.persist()
+            if self.matrix_type == "short-and-fat":
+                self.v = self.v.persist()
+        except Exception as e:
+            msg = "Failed transforming input matrix."
+            logger.exception(msg)
+            raise RuntimeError(msg) from e

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -252,6 +252,24 @@ class TruncatedSVD(SVD):
             logger.exception(msg)
             raise RuntimeError(msg) from e
 
+    def transform(self):
+        if self._decomposer is None:
+            msg = "You have to call `fit` before you can call `transform`."
+            logger.exception(msg)
+            raise RuntimeError(msg)
+        try:
+            if self.matrix_type == "tall-and-skinny":
+                X_transformed = self._decomposer.transform(self.X)
+                self.u = X_transformed / self._decomposer.singular_values_  # unscaled
+            if self.matrix_type == "short-and-fat":
+                X_transformed_t = self._decomposer.transform(self.X.T)
+                u_t = X_transformed_t / self._decomposer.singular_values_  # unscaled
+                self.v = u_t.T
+        except Exception as e:
+            msg = "Failed transforming input matrix."
+            logger.exception(msg)
+            raise RuntimeError(msg) from e
+
 
 class RandomizedSVD(SVD):
     """

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -108,44 +108,12 @@ class SVD(ABC):
 
 
 class ExactSVD(SVD):
-    """
-    ExactSVD performs an exact Singular Value Decomposition (SVD)
+    """Performs an exact Singular Value Decomposition (SVD)
     on a Dask array.
 
-    This class inherits from the SVD base class and implements
-    the exact SVD algorithm for matrices that are either
-    tall-and-skinny or short-and-fat, with an aspect ratio >= 10.
-    It rechunks the input array as needed to optimize SVD
-    computation and raises an exception if the matrix is square,
-    recommending the use of randomized SVD instead.
-
-    Parameters
-    ----------
-    X : dask.array.Array
-        The input matrix to decompose.
-
-    Attributes
-    ----------
-    u : dask.array.Array
-        Left singular vectors, shape (n_samples, n_components).
-    s : numpy.ndarray
-        Singular values, shape (n_components,).
-    v : dask.array.Array
-        Right singular vectors, shape (n_components, n_features).
-
-    Methods
-    -------
-    fit(n_components, **kwargs)
-        Computes the exact SVD and stores the top `n_components`
-        left singular vectors (`u`), singular values (`s`),
-        and right singular vectors (`v`). Passes additional
-        keyword arguments to the underlying SVD computation
-        (see `dask.array.linalg.svd` for details).
-
-    Raises
-    ------
-    RuntimeError
-        If the input matrix is square/nearly square or if SVD computation fails.
+    Inherits from the SVD base class and implements
+    Dask's exact SVD algorithm for matrices that are either
+    tall-and-skinny or short-and-fat.
     """
 
     def __init__(self, X):
@@ -160,6 +128,10 @@ class ExactSVD(SVD):
             raise RuntimeError(msg)
 
     def fit(self, n_components=-1, transform=False, **kwargs):
+        """The default value for `n_components` is -1, meaning
+        keep all SVD components. For additional keyword arguments,
+        see the documentation for `dask.array.linalg.svd`.
+        """
         self.n_components = n_components
         self.X = self.X.persist()
         try:

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -52,27 +52,25 @@ class TestSVD:
             n_components = 10
             exact_svd = ExactSVD(self.X)
             exact_svd.fit(n_components, transform=True)
-            assert isinstance(exact_svd.u, da.Array), (
-                "The u matrix should be of type dask.array.Array, "
-                f"not {type(exact_svd.u)}."
-            )
-            assert isinstance(exact_svd.v, da.Array), (
-                "The v matrix should be of type dask.array.Array, "
-                f"not {type(exact_svd.v)}."
-            )
-            assert isinstance(exact_svd.s, np.ndarray), (
-                "The s vector should be of type numpy.ndarray, "
-                f"not {type(exact_svd.s)}."
-            )
-            assert exact_svd.u.shape == (
+            u, s, v = exact_svd.u, exact_svd.s, exact_svd.v
+            assert isinstance(
+                u, da.Array
+            ), f"The u matrix should be of type dask.array.Array, not {type(u)}."
+            assert isinstance(
+                v, da.Array
+            ), f"The v matrix should be of type dask.array.Array, not {type(v)}."
+            assert isinstance(
+                s, np.ndarray
+            ), f"The s vector should be of type numpy.ndarray, not {type(s)}."
+            assert u.shape == (
                 n_rows,
                 n_components,
             ), "The u matrix should have shape (n_samples, n_components)."
-            assert exact_svd.v.shape == (
+            assert v.shape == (
                 n_components,
                 n_cols,
             ), "The v matrix should have shape (n_components, n_features)."
-            assert exact_svd.s.shape == (
+            assert s.shape == (
                 n_components,
             ), "The s vector should have shape (n_components,)."
 
@@ -82,36 +80,33 @@ class TestSVD:
         n_components = 10
         randomized_svd = RandomizedSVD(self.X)
         randomized_svd.fit(n_components)
-        assert isinstance(randomized_svd.u, da.Array), (
-            "The u matrix should be of type dask.array.Array, "
-            f"not {type(randomized_svd.u)}."
-        )
-        assert isinstance(randomized_svd.v, da.Array), (
-            "The v matrix should be of type dask.array.Array, "
-            f"not {type(randomized_svd.v)}."
-        )
-        assert isinstance(randomized_svd.s, np.ndarray), (
-            "The s vector should be of type numpy.ndarray, "
-            f"not {type(randomized_svd.s)}."
-        )
-        assert randomized_svd.u.shape == (
+        u, s, v = randomized_svd.u, randomized_svd.s, randomized_svd.v
+        assert isinstance(
+            u, da.Array
+        ), f"The u matrix should be of type dask.array.Array, not {type(u)}."
+        assert isinstance(
+            v, da.Array
+        ), f"The v matrix should be of type dask.array.Array, not {type(v)}."
+        assert isinstance(
+            s, np.ndarray
+        ), f"The s vector should be of type numpy.ndarray, not {type(s)}."
+        assert u.shape == (
             n_rows,
             n_components,
         ), (
             f"The u matrix should have shape ({n_rows}, {n_components}), "
-            f"but got {randomized_svd.u.shape}."
+            f"but got {u.shape}."
         )
-        assert randomized_svd.v.shape == (
+        assert v.shape == (
             n_components,
             n_cols,
         ), (
             f"The v matrix should have shape ({n_components}, {n_cols}), "
-            f"but got {randomized_svd.v.shape}."
+            f"but got {v.shape}."
         )
-        assert randomized_svd.s.shape == (n_components,), (
-            f"The s vector should have shape ({n_components},), "
-            f"but got {randomized_svd.s.shape}."
-        )
+        assert s.shape == (
+            n_components,
+        ), f"The s vector should have shape ({n_components},), but got {s.shape}."
 
     def test_truncated_svd(self, matrix_type, n_rows, n_cols):
         print(f"Running truncated SVD test for {matrix_type} matrix.")

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -93,7 +93,7 @@ class TestSVD:
         self._make_matrix(n_rows, n_cols)
         n_components = 10
         randomized_svd = RandomizedSVD(self.X)
-        randomized_svd.fit(n_components)
+        randomized_svd.fit(n_components, transform=True)
 
         assert hasattr(
             randomized_svd, "u"

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -39,6 +39,8 @@ class TestSVD:
         Checks output types and shapes for correctness.
     """
 
+    n_components = 10
+
     def _make_matrix(self, n_rows, n_cols):
         self.X = da.random.random((n_rows, n_cols), chunks="auto").astype("float32")
 
@@ -49,9 +51,8 @@ class TestSVD:
             with pytest.raises(RuntimeError):
                 exact_svd = ExactSVD(self.X)
         else:
-            n_components = 10
             exact_svd = ExactSVD(self.X)
-            exact_svd.fit(n_components, transform=True)
+            exact_svd.fit(self.n_components, transform=True)
 
             assert hasattr(
                 exact_svd, "u"
@@ -78,22 +79,21 @@ class TestSVD:
             ), f"The s vector should be of type numpy.ndarray, not {type(s)}."
             assert u.shape == (
                 n_rows,
-                n_components,
+                self.n_components,
             ), "The u matrix should have shape (n_samples, n_components)."
             assert v.shape == (
-                n_components,
+                self.n_components,
                 n_cols,
             ), "The v matrix should have shape (n_components, n_features)."
             assert s.shape == (
-                n_components,
+                self.n_components,
             ), "The s vector should have shape (n_components,)."
 
     def test_randomized_svd(self, matrix_type, n_rows, n_cols):
         print(f"Running randomized SVD test for {matrix_type} matrix.")
         self._make_matrix(n_rows, n_cols)
-        n_components = 10
         randomized_svd = RandomizedSVD(self.X)
-        randomized_svd.fit(n_components, transform=True)
+        randomized_svd.fit(self.n_components, transform=True)
 
         assert hasattr(
             randomized_svd, "u"
@@ -120,33 +120,32 @@ class TestSVD:
         ), f"The s vector should be of type numpy.ndarray, not {type(s)}."
         assert u.shape == (
             n_rows,
-            n_components,
+            self.n_components,
         ), (
-            f"The u matrix should have shape ({n_rows}, {n_components}), "
+            f"The u matrix should have shape ({n_rows}, {self.n_components}), "
             f"but got {u.shape}."
         )
         assert v.shape == (
-            n_components,
+            self.n_components,
             n_cols,
         ), (
-            f"The v matrix should have shape ({n_components}, {n_cols}), "
+            f"The v matrix should have shape ({self.n_components}, {n_cols}), "
             f"but got {v.shape}."
         )
         assert s.shape == (
-            n_components,
-        ), f"The s vector should have shape ({n_components},), but got {s.shape}."
+            self.n_components,
+        ), f"The s vector should have shape ({self.n_components},), but got {s.shape}."
 
     def test_truncated_svd(self, matrix_type, n_rows, n_cols):
         print(f"Running truncated SVD test for {matrix_type} matrix.")
         self._make_matrix(n_rows, n_cols)
-        n_components = 10
 
         if matrix_type == "square":
             with pytest.raises(RuntimeError):
                 TruncatedSVD(self.X)
         else:
             truncated_svd = TruncatedSVD(self.X)
-            truncated_svd.fit(n_components=n_components, transform=True)
+            truncated_svd.fit(n_components=self.n_components, transform=True)
 
             assert hasattr(
                 truncated_svd, "u"
@@ -173,21 +172,21 @@ class TestSVD:
                 v, da.Array
             ), f"The v matrix should be of type dask.array.Array, not {type(v)}."
 
-            assert u.shape == (n_rows, n_components), (
-                f"The u matrix should have shape ({n_rows}, {n_components}), "
+            assert u.shape == (n_rows, self.n_components), (
+                f"The u matrix should have shape ({n_rows}, {self.n_components}), "
                 f"but got {u.shape}."
             )
-            assert s.shape == (n_components,), (
-                f"The s vector should have shape ({n_components},), "
+            assert s.shape == (self.n_components,), (
+                f"The s vector should have shape ({self.n_components},), "
                 f"but got {s.shape}."
             )
-            assert v.shape == (n_components, n_cols), (
-                f"The v matrix should have shape ({n_components}, {n_cols}), "
+            assert v.shape == (self.n_components, n_cols), (
+                f"The v matrix should have shape ({self.n_components}, {n_cols}), "
                 f"but got {v.shape}."
             )
 
             # check orthogonality
-            identity_k = np.eye(n_components, dtype=np.float32)
+            identity_k = np.eye(self.n_components, dtype=np.float32)
             u_ortho = (u.T @ u).compute()
             v_ortho = (v @ v.T).compute()
 

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -52,6 +52,20 @@ class TestSVD:
             n_components = 10
             exact_svd = ExactSVD(self.X)
             exact_svd.fit(n_components, transform=True)
+
+            assert hasattr(
+                exact_svd, "u"
+            ), "The exact_svd object should have attribute 'u'."
+            assert hasattr(
+                exact_svd, "s"
+            ), "The exact_svd object should have attribute 's'."
+            assert hasattr(
+                exact_svd, "v"
+            ), "The exact_svd object should have attribute 'v'."
+            assert hasattr(
+                exact_svd, "n_components"
+            ), "The exact_svd object should have attribute 'n_components'."
+
             u, s, v = exact_svd.u, exact_svd.s, exact_svd.v
             assert isinstance(
                 u, da.Array
@@ -80,6 +94,20 @@ class TestSVD:
         n_components = 10
         randomized_svd = RandomizedSVD(self.X)
         randomized_svd.fit(n_components)
+
+        assert hasattr(
+            randomized_svd, "u"
+        ), "The randomized_svd object should have attribute 'u'."
+        assert hasattr(
+            randomized_svd, "s"
+        ), "The randomized_svd object should have attribute 's'."
+        assert hasattr(
+            randomized_svd, "v"
+        ), "The randomized_svd object should have attribute 'v'."
+        assert hasattr(
+            randomized_svd, "n_components"
+        ), "The randomized_svd object should have attribute 'n_components'."
+
         u, s, v = randomized_svd.u, randomized_svd.s, randomized_svd.v
         assert isinstance(
             u, da.Array
@@ -129,6 +157,9 @@ class TestSVD:
             assert hasattr(
                 truncated_svd, "v"
             ), "The truncated_svd object should have attribute 'v'."
+            assert hasattr(
+                truncated_svd, "n_components"
+            ), "The truncated_svd object should have attribute 'n_components'."
 
             u, s, v = truncated_svd.u, truncated_svd.s, truncated_svd.v
 

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -51,7 +51,7 @@ class TestSVD:
         else:
             n_components = 10
             exact_svd = ExactSVD(self.X)
-            exact_svd.fit(n_components)
+            exact_svd.fit(n_components, transform=True)
             assert isinstance(exact_svd.u, da.Array), (
                 "The u matrix should be of type dask.array.Array, "
                 f"not {type(exact_svd.u)}."
@@ -123,7 +123,7 @@ class TestSVD:
                 TruncatedSVD(self.X)
         else:
             truncated_svd = TruncatedSVD(self.X)
-            truncated_svd.fit(n_components=n_components)
+            truncated_svd.fit(n_components=n_components, transform=True)
 
             assert hasattr(
                 truncated_svd, "u"


### PR DESCRIPTION
The main change introduced is the incorporation of a `transform` method in the SVD classes, and a `transform` argument in the already existing `fit` method. This allows to request small SVD results only (`s` and `v` for a tall-and-skinny matrix or `s` and `u` for a short-and-fat matrix) when calling `fit()` with `transform=False`. If the user wants to compute the remaining SVD results at a later stage (i.e. `u` for a tall-and-skinny matrix or `v` for a short-and-fat matrix), they can call `transform()`. The point of this is to avoid computing the transformed array, which can be very large, on distributed RAM if the user does not require it.

Other changes introduced by this PR include:

* Transforming SVD instance attributes into non-public attributes and creating corresponding properties
* Tidying up docstrings
* Testing for attribute existence in `test_exact_svd` and `test_randomized_svd` tests
* Set default value for `n_components` argument in `ExactSVD.fit()` to -1, to compute all possible SVD components

Closes #7