### PR TITLE
Preprocessing

### DIFF
--- a/src/svdrom/preprocessing.py
+++ b/src/svdrom/preprocessing.py
@@ -82,7 +82,7 @@ class StandardScaler:
         """Whether data scaled to unit variance or not (read_only)."""
         return self._with_std
 
-    def scale(
+    def __call__(
         self,
         X: xr.Dataset | xr.DataArray,
         dim: str = "time",

--- a/src/svdrom/preprocessing.py
+++ b/src/svdrom/preprocessing.py
@@ -1,0 +1,72 @@
+from collections.abc import Sequence
+
+import dask.array as da
+import numpy as np
+import xarray as xr
+from dask_ml.preprocessing import StandardScaler as ss
+
+
+class ArrayPreprocessor:
+    def spatial_stack(
+        self, X: xr.Dataset | xr.DataArray, dims: Sequence[str]
+    ) -> xr.Dataset | xr.DataArray:
+        """Given an input array, create a single spatial dimension
+        by stacking multiple dimensions together. This operation is lazy.
+
+        Parameters
+        ----------
+        X (xr.Dataset | xr.DataArray): the input array to stack.
+        dims (Iterable[str]): the dimensions to stack together into a
+        single spatial dimension.
+
+        Returns
+        -------
+        xr.Dataset | xr.DataArray: The array with the specified
+        dimensions stacked into a single spatial dimension.
+
+        Notes
+        -----
+        This method preserves the data type of the input. If a DataArray is provided,
+        a DataArray is returned. If a Dataset is provided, a Dataset is returned.
+        """
+
+        all_dims: list[str] = list(map(str, X.sizes.keys()))
+        if not all(dim in all_dims for dim in dims):
+            msg = (
+                f"Some dimensions {dims} are not present in the input array "
+                f"with dimensions {all_dims}."
+            )
+            raise ValueError(msg)
+
+        return X.stack(space=dims)
+
+    def variable_stack(self, X: xr.Dataset, variables: Sequence[str]) -> xr.DataArray:
+        """Given a xarray.Dataset containing multiple variables,
+        return a xarray.DataArray where the specified variables
+        have been stacked along the spatial dimension.
+
+        Not yet implemented.
+        """
+        pass
+
+
+class StandardScaler(ArrayPreprocessor):
+    def __init__(self):
+        self._mean = np.empty_like(0)
+        self._std = np.empty_like(0)
+        self._with_mean = False
+        self._with_std = False
+        self._scaler = None
+
+    def fit(
+        self,
+        X: da.Array | xr.Dataset | xr.DataArray,
+        dim="time",
+        with_mean: bool = True,
+        with_std: bool = False,
+        transform: bool = False,
+    ):
+        pass
+
+    def transform(self):
+        pass

--- a/src/svdrom/preprocessing.py
+++ b/src/svdrom/preprocessing.py
@@ -1,9 +1,7 @@
 from collections.abc import Sequence
 
-import dask.array as da
 import numpy as np
 import xarray as xr
-from dask_ml.preprocessing import StandardScaler as ss
 
 
 class ArrayPreprocessor:
@@ -40,33 +38,84 @@ class ArrayPreprocessor:
 
         return X.stack(space=dims)
 
-    def variable_stack(self, X: xr.Dataset, variables: Sequence[str]) -> xr.DataArray:
+    def variable_stack(self, X: xr.Dataset, variables: Sequence[str]):
         """Given a xarray.Dataset containing multiple variables,
         return a xarray.DataArray where the specified variables
         have been stacked along the spatial dimension.
 
         Not yet implemented.
         """
-        pass
+        return
 
 
 class StandardScaler(ArrayPreprocessor):
+    """Preprocessing class for scaling Xarray datasets or data arrays
+    by removing the mean and optionally scaling by the standard deviation
+    along a specified dimension.
+
+    Attributes
+    ----------
+    mean (xr.DataArray | xr.Dataset): the mean values computed along the
+    specified dimension.
+    std (xr.DataArray | xr.Dataset): the standard deviation values computed
+    along the specified dimension.
+    with_std (bool): whether the data has been scaled to unit variance.
+    """
+
     def __init__(self):
-        self._mean = np.empty_like(0)
-        self._std = np.empty_like(0)
-        self._with_mean = False
+        self._mean = xr.DataArray(np.zeros_like(0))
+        self._std = xr.DataArray(np.zeros_like(0))
         self._with_std = False
-        self._scaler = None
 
-    def fit(
+    @property
+    def mean(self) -> xr.DataArray | xr.Dataset:
+        """Mean (read-only)."""
+        return self._mean
+
+    @property
+    def std(self) -> xr.DataArray | xr.Dataset:
+        """Standard deviation (read-only)."""
+        return self._std
+
+    @property
+    def with_std(self) -> bool:
+        """Whether data scaled to unit variance or not (read_only)."""
+        return self._with_std
+
+    def scale(
         self,
-        X: da.Array | xr.Dataset | xr.DataArray,
-        dim="time",
-        with_mean: bool = True,
+        X: xr.Dataset | xr.DataArray,
+        dim: str = "time",
         with_std: bool = False,
-        transform: bool = False,
     ):
-        pass
+        """
+        Scales the input xarray Dataset or DataArray by removing the mean
+        and optionally dividing by the standard deviation.
 
-    def transform(self):
-        pass
+        Parameters:
+        -----------
+        X (xr.Dataset | xr.DataArray): the input xarray object to be scaled.
+        dim (str): the dimension along which to compute the mean and
+        standard deviation. Default is "time".
+        with_std (bool): if True, scales the data by dividing by the standard
+        deviation after subtracting the mean. Default is False.
+
+        Returns:
+        --------
+        xr.Dataset | xr.DataArray: the scaled xarray object with the mean removed,
+        and optionally divided by the standard deviation.
+
+        Note
+        ----
+        The mean and standard deviation are computed eagerly and stored as NumPy-backed
+        xarray objects. The returned xarray object is Dask-backed and lazy if the input
+        is Dask-backed.
+        """
+        self._with_std = with_std
+        self._mean = X.mean(dim=dim)
+        self._mean = self._mean.compute()
+        if self._with_std:
+            self._std = X.std(dim=dim)
+            self._std = self._std.compute()
+            return (X - self._mean) / self._std
+        return X - self._mean

--- a/src/svdrom/preprocessing.py
+++ b/src/svdrom/preprocessing.py
@@ -4,52 +4,51 @@ import numpy as np
 import xarray as xr
 
 
-class ArrayPreprocessor:
-    def variable_spatial_stack(
-        self, X: xr.Dataset | xr.DataArray, dims: Sequence[str]
-    ) -> xr.DataArray:
-        """Stack multiple dimensions of an input Xarray Dataset or
-        DataArray into a single new 'samples' dimension.
+def variable_spatial_stack(
+    X: xr.Dataset | xr.DataArray, dims: Sequence[str]
+) -> xr.DataArray:
+    """Stack multiple dimensions of an input Xarray Dataset or
+    DataArray into a single new 'samples' dimension.
 
-        Parameters
-        ----------
-        X (xr.Dataset | xr.DataArray): the input data to stack.
-        dims (Iterable[str]): the dimensions to stack together into a
-        single spatial dimension (e.g. ('x', 'y') or ('lat', 'lon')).
+    Parameters
+    ----------
+    X (xr.Dataset | xr.DataArray): the input data to stack.
+    dims (Iterable[str]): the dimensions to stack together into a
+    single spatial dimension (e.g. ('x', 'y') or ('lat', 'lon')).
 
-        Returns
-        -------
-        xr.DataArray: The array with the specified dimensions stacked
-        into a single spatial dimension.
+    Returns
+    -------
+    xr.DataArray: The array with the specified dimensions stacked
+    into a single spatial dimension.
 
-        Notes
-        -----
-        If the input Xarray object is a Dataset containing multiple variables,
-        all variables will be stacked together along the new 'samples' dimension.
-        The resulting DataArray will have a 'samples' dimension that combines
-        the specified spatial dimensions (and the variable dimension if the input
-        was a Dataset).
-        The returned xarray object is Dask-backed and lazy if the input
-        is Dask-backed.
-        """
+    Notes
+    -----
+    If the input Xarray object is a Dataset containing multiple variables,
+    all variables will be stacked together along the new 'samples' dimension.
+    The resulting DataArray will have a 'samples' dimension that combines
+    the specified spatial dimensions (and the variable dimension if the input
+    was a Dataset).
+    The returned xarray object is Dask-backed and lazy if the input
+    is Dask-backed.
+    """
 
-        dims = list(dims)
-        if isinstance(X, xr.Dataset):
-            X = X.to_dataarray(dim="variable")
-            dims.insert(0, "variable")
+    dims = list(dims)
+    if isinstance(X, xr.Dataset):
+        X = X.to_dataarray(dim="variable")
+        dims.insert(0, "variable")
 
-        all_dims: list[str] = list(map(str, X.sizes.keys()))
-        if not all(dim in all_dims for dim in dims):
-            msg = (
-                f"Some dimensions {dims} are not present in the input array "
-                f"with dimensions {all_dims}."
-            )
-            raise ValueError(msg)
+    all_dims: list[str] = list(map(str, X.sizes.keys()))
+    if not all(dim in all_dims for dim in dims):
+        msg = (
+            f"Some dimensions {dims} are not present in the input array "
+            f"with dimensions {all_dims}."
+        )
+        raise ValueError(msg)
 
-        return X.stack(samples=dims)
+    return X.stack(samples=dims)
 
 
-class StandardScaler(ArrayPreprocessor):
+class StandardScaler:
     """Preprocessing class for scaling Xarray datasets or data arrays
     by removing the mean and optionally scaling by the standard deviation
     along a specified dimension.
@@ -89,9 +88,8 @@ class StandardScaler(ArrayPreprocessor):
         dim: str = "time",
         with_std: bool = False,
     ):
-        """
-        Scales the input xarray Dataset or DataArray by removing the mean
-        and optionally dividing by the standard deviation.
+        """Scales the input xarray Dataset or DataArray by removing
+        the mean and optionally dividing by the standard deviation.
 
         Parameters:
         -----------

--- a/src/svdrom/preprocessing.py
+++ b/src/svdrom/preprocessing.py
@@ -3,6 +3,10 @@ from collections.abc import Sequence
 import numpy as np
 import xarray as xr
 
+from svdrom.logger import setup_logger
+
+logger = setup_logger("Preprocessing", "preprocessing.log")
+
 
 def variable_spatial_stack(
     X: xr.Dataset | xr.DataArray, dims: Sequence[str]
@@ -34,6 +38,8 @@ def variable_spatial_stack(
 
     dims = list(dims)
     if isinstance(X, xr.Dataset):
+        msg = "Performing variable stacking."
+        logger.info(msg)
         X = X.to_dataarray(dim="variable")
         dims.insert(0, "variable")
 
@@ -43,8 +49,11 @@ def variable_spatial_stack(
             f"Some dimensions {dims} are not present in the input array "
             f"with dimensions {all_dims}."
         )
+        logger.exception(msg)
         raise ValueError(msg)
 
+    msg = "Performing spatial stacking."
+    logger.info(msg)
     return X.stack(samples=dims)
 
 
@@ -112,9 +121,17 @@ class StandardScaler:
         """
         self._with_std = with_std
         self._mean = X.mean(dim=dim)
+        msg = f"Computing mean along dimension {dim}..."
+        logger.info(msg)
         self._mean = self._mean.compute()
+        msg = "Finished computing mean."
+        logger.info(msg)
         if self._with_std:
             self._std = X.std(dim=dim)
+            msg = f"Computing std along dimension {dim}..."
+            logger.info(msg)
             self._std = self._std.compute()
+            msg = "Finished computing std."
+            logger.info(msg)
             return (X - self._mean) / self._std
         return X - self._mean

--- a/src/svdrom/preprocessing.py
+++ b/src/svdrom/preprocessing.py
@@ -1,6 +1,5 @@
 from collections.abc import Sequence
 
-import numpy as np
 import xarray as xr
 
 from svdrom.logger import setup_logger
@@ -72,17 +71,17 @@ class StandardScaler:
     """
 
     def __init__(self):
-        self._mean = xr.DataArray(np.zeros_like(0))
-        self._std = xr.DataArray(np.zeros_like(0))
+        self._mean = None
+        self._std = None
         self._with_std = False
 
     @property
-    def mean(self) -> xr.DataArray | xr.Dataset:
+    def mean(self) -> xr.DataArray | xr.Dataset | None:
         """Mean (read-only)."""
         return self._mean
 
     @property
-    def std(self) -> xr.DataArray | xr.Dataset:
+    def std(self) -> xr.DataArray | xr.Dataset | None:
         """Standard deviation (read-only)."""
         return self._std
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -45,16 +45,11 @@ def test_variable_spatial_stack(X: xr.DataArray | xr.Dataset):
 
     # check that by unstacking we can recover the original
     X_unstacked = X_stacked.unstack()
-    X = X.transpose("x", "y", "z", "time")
     if isinstance(X, xr.DataArray):
-        X_unstacked = X_unstacked.transpose("x", "y", "z", "time")
-        assert X.equals(
-            X_unstacked
-        ), "Unstacking should recover the original DataArray."
+        xr.testing.assert_allclose(X, X_unstacked, check_dim_order=False)
     if isinstance(X, xr.Dataset):
-        X_unstacked = X_unstacked.transpose("x", "y", "z", "time", "variable")
         X_unstacked = X_unstacked.to_dataset(dim="variable")
-        assert X.equals(X_unstacked), "Unstacking should recover the original Dataset."
+        xr.testing.assert_allclose(X, X_unstacked, check_dim_order=False)
 
 
 @pytest.mark.parametrize("X", [generator.da, generator.ds])

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -72,7 +72,10 @@ def test_standard_scaler(X: xr.DataArray | xr.Dataset):
         assert isinstance(
             scaler.std, xr.DataArray
         ), f"Expected std to be a DataArray, got {type(scaler.std).__name__}."
-        xr.testing.assert_allclose(X, X_scaled * scaler.std + scaler.mean)
+        if scaler.with_std:
+            xr.testing.assert_allclose(X, X_scaled * scaler.std + scaler.mean)
+        else:
+            xr.testing.assert_allclose(X, X_scaled + scaler.mean)
     if isinstance(X, xr.Dataset):
         assert isinstance(
             X_scaled, xr.Dataset
@@ -83,4 +86,7 @@ def test_standard_scaler(X: xr.DataArray | xr.Dataset):
         assert isinstance(
             scaler.std, xr.Dataset
         ), f"Expected std to be a Dataset, got {type(scaler.std).__name__}."
-        xr.testing.assert_allclose(X, X_scaled * scaler.std + scaler.mean)
+        if scaler.with_std:
+            xr.testing.assert_allclose(X, X_scaled * scaler.std + scaler.mean)
+        else:
+            xr.testing.assert_allclose(X, X_scaled + scaler.mean)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,18 @@
+import pytest
+from make_test_data import DataGenerator
+
+from svdrom.preprocessing import variable_spatial_stack
+
+generator = DataGenerator()
+generator.generate_dataarray()
+generator.generate_dataset()
+
+
+@pytest.mark.parametrize("X", [generator.da, generator.ds])
+def test_variable_spatial_stack(X):
+    X_stacked = variable_spatial_stack(X, dims=("x", "y", "z"))
+    dims = sorted(map(str, X_stacked.sizes.keys()))
+    expected_dims = sorted(["time", "samples"])
+    assert (
+        dims == expected_dims
+    ), f"Expected dimensions after stacking are {expected_dims}, got {dims}."

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,4 +1,5 @@
 import pytest
+import xarray as xr
 from make_test_data import DataGenerator
 
 from svdrom.preprocessing import variable_spatial_stack
@@ -9,10 +10,48 @@ generator.generate_dataset()
 
 
 @pytest.mark.parametrize("X", [generator.da, generator.ds])
-def test_variable_spatial_stack(X):
+def test_variable_spatial_stack(X: xr.DataArray | xr.Dataset):
+    """Test for the variable_spatial_stack function."""
+    # check that the output is a xarray DataArray
     X_stacked = variable_spatial_stack(X, dims=("x", "y", "z"))
+    assert isinstance(X_stacked, xr.DataArray), (
+        "The result of stacking should be a Xarray DataArray, ",
+        f"got {type(X_stacked).__name__}.",
+    )
+
+    # check that the dimensions are "time" and "samples"
     dims = sorted(map(str, X_stacked.sizes.keys()))
     expected_dims = sorted(["time", "samples"])
     assert (
         dims == expected_dims
     ), f"Expected dimensions after stacking are {expected_dims}, got {dims}."
+
+    # check if shape matches expected shape
+    X_stacked = X_stacked.transpose("samples", "time")
+    len_x, len_y, len_z = len(X.x), len(X.y), len(X.z)
+    if isinstance(X, xr.DataArray):
+        expected_shape = (len_x * len_y * len_z, len(X.time))
+        assert expected_shape == X_stacked.shape, (
+            f"Expected shape for a DataArray after stacking is {expected_shape}, ",
+            f"got {X_stacked.shape}.",
+        )
+    if isinstance(X, xr.Dataset):
+        vars = list(X.keys())
+        expected_shape = (len_x * len_y * len_z * len(vars), len(X.time))
+        assert expected_shape == X_stacked.shape, (
+            f"Expected shape for a Dataset after stacking is {expected_shape}, ",
+            f"got {X_stacked.shape}.",
+        )
+
+    # check that by unstacking we can recover the original
+    X_unstacked = X_stacked.unstack()
+    X = X.transpose("x", "y", "z", "time")
+    if isinstance(X, xr.DataArray):
+        X_unstacked = X_unstacked.transpose("x", "y", "z", "time")
+        assert X.equals(
+            X_unstacked
+        ), "Unstacking should recover the original DataArray."
+    if isinstance(X, xr.Dataset):
+        X_unstacked = X_unstacked.transpose("x", "y", "z", "time", "variable")
+        X_unstacked = X_unstacked.to_dataset(dim="variable")
+        assert X.equals(X_unstacked), "Unstacking should recover the original Dataset."


### PR DESCRIPTION
This PR introduces pre-processing functionality in SVDROM.

The `preprocessing.py` module introduces:

* The `variable_spatial_stack` function, which stacks all variables (in case of a Dataset) and the specified spatial dimensions (for DataArrays and Datasets) along a new dimension called `samples`, which is MultiIndex. The resulting DataArray can be unstacked to recover the original.
* The `StandardScaler` class, which calculates the mean and standard deviation of a DataArray or Dataset along a specified dimension and scales the input data. The calculations of the mean and std are performed eagerly and are blocking, while the scaling operation is lazy for a Dask-backed Xarray object.

Tests for the preprocessing functionality are also included.

Closes #8.