### PR TITLE
Refactor SVD implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ Thumbs.db
 # Common editor files
 *~
 *.swp
+
+# VS Code
+.vscode/

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -18,6 +18,51 @@ class TruncatedSVD:
         compute_var_ratio: bool = False,
         rechunk: bool = False,
     ):
+        """Linear dimensionality reduction using truncated
+        Singular Value Decomposition (SVD).
+
+        This class follows heavily the design of
+        `dask_ml.decomposition.TruncatedSVD`, but it has been
+        modified to work with Dask-backed Xarray DataArrays.
+
+        Parameters
+        ----------
+        n_components: int
+            Number of SVD components to keep. Must be less than
+            the number of features of the input array.
+        algorithm: str, {'tsqr', 'randomized'}, (default 'tsqr')
+            SVD algorithm to use. 'tsqr' only supports chunking
+            along one dimension (i.e. the array should be tall-and-skinny
+            or short-and-fat), while 'randomized' supports chunking
+            in both dimensions. 'tsqr' is more precise, but it is slower
+            and struggles to operate on very large arrays. 'randomized' is
+            less precise but is much faster and can more easily operate on
+            very large arrays. See the Notes section for more.
+        compute_u: bool, (default True)
+            Whether to eagerly compute the left singular vectors, `u`. If
+            set to False, the computational graph for `u` is built but not
+            computed and `u` is returned as a lazy Dask collection.
+        compute_v: bool, (default True)
+            Whether to eagerly compute the right singular vectors, `v`. If
+            set to False, the computational graph for `v` is built but not
+            computed and `v` is returned as a lazy Dask collection.
+        compute_var_ratio: bool, (default False)
+            Whether to eagerly compute the ratio of explained variance by
+            each SVD component. If False, the computational graph is built
+            but not computed and is returned as a lazy Dask collection.
+        rechunk: bool, (default False)
+            If using the 'randomized' algorithm, whether to rechunk the input
+            array to ensure a single chunk along the smallest dimension.
+            Rechunking will always be performed when using the 'tsqr' algorithm
+            if the input array requires it, regardless of this parameter.
+
+        Notes
+        -----
+        The 'tsqr' algorithm is implemented via Dask's `dask.array.linalg.svd`
+        function. The 'randomized' algorithm is implemented via Dask's
+        `dask.array.linalg.svd_compressed` function.
+        """
+
         self._n_components = n_components
         self._algorithm = algorithm
         self._compute_u = compute_u

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -12,11 +12,17 @@ class TruncatedSVD:
         self,
         n_components: int,
         algorithm: str = "tsqr",
+        compute_u: bool = True,
+        compute_v: bool = True,
+        compute_var_ratio: bool = False,
         rechunk: bool = True,
         aspect_ratio: int = 10,
     ):
         self._n_components = n_components
         self._algorithm = algorithm
+        self._compute_u = compute_u
+        self._compute_v = compute_v
+        self._compute_var_ratio = compute_var_ratio
         self._rechunk = rechunk
         self._aspect_ratio = aspect_ratio
         self._u: xr.DataArray | None = None
@@ -48,6 +54,31 @@ class TruncatedSVD:
     def matrix_type(self):
         """Matrix type, based on aspect radio (read-only)."""
         return self._matrix_type
+
+    @property
+    def compute_u(self):
+        """Whether to compute left singular vectors (read-only)."""
+        return self._compute_u
+
+    @property
+    def compute_v(self):
+        """Whether to compute right singular vectors (read-only)."""
+        return self._compute_v
+
+    @property
+    def compute_var_ratio(self):
+        """Whether to compute the ratio of explained variance (read-only)."""
+        return self._compute_var_ratio
+
+    @property
+    def aspect_ratio(self):
+        """Aspect ratio used to determine matrix type (read-only)."""
+        return self._aspect_ratio
+
+    @property
+    def rechunk(self):
+        """Whether to rechunk the input array before fitting (read-only)."""
+        return self._rechunk
 
     def _check_matrix_type(self, X: da.Array):
         """Checks if input matrix is tall-and-skinny,
@@ -82,9 +113,6 @@ class TruncatedSVD:
     def fit(
         self,
         X: xr.DataArray,
-        compute_u: bool = True,
-        compute_v: bool = True,
-        compute_var_ratio: bool = False,
     ):
         pass
 

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -72,7 +72,7 @@ class TruncatedSVD:
         self._u: xr.DataArray | None = None
         self._s: np.ndarray | None = None
         self._v: xr.DataArray | None = None
-        self._explained_var_ratio: np.ndarray | None = None
+        self._explained_var_ratio: np.ndarray | da.Array | None = None
 
     @property
     def n_components(self) -> int:
@@ -98,11 +98,6 @@ class TruncatedSVD:
     def explained_var_ratio(self):
         """Ratio of explained variance (read-only)."""
         return self._explained_var_ratio
-
-    @property
-    def compute_var_ratio(self):
-        """Whether to compute the ratio of explained variance (read-only)."""
-        return self._compute_var_ratio
 
     @property
     def algorithm(self):
@@ -281,6 +276,21 @@ class TruncatedSVD:
         msg = "Computing right singular vectors..."
         logger.info(msg)
         self._v = self._v.compute()
+        msg = "Done."
+        logger.info(msg)
+
+    def compute_var_ratio(self) -> None:
+        """Compute the ratio of explained variance if it is
+        still a lazy Dask collection.
+        """
+        if self._explained_var_ratio is None:
+            msg = "You must call fit() before calling compute_var_ratio()."
+            logger.exception(msg)
+            raise ValueError(msg)
+        msg = "Computing explained variance ratio..."
+        logger.info(msg)
+        if isinstance(self._explained_var_ratio, da.Array):
+            self._explained_var_ratio = self._explained_var_ratio.compute()
         msg = "Done."
         logger.info(msg)
 

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -16,7 +16,7 @@ class TruncatedSVD:
         compute_u: bool = True,
         compute_v: bool = True,
         compute_var_ratio: bool = False,
-        rechunk: bool = True,
+        rechunk: bool = False,
         aspect_ratio: int = 10,
     ):
         self._n_components = n_components

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -19,10 +19,35 @@ class TruncatedSVD:
         self._algorithm = algorithm
         self._rechunk = rechunk
         self._aspect_ratio = aspect_ratio
-        self._u = xr.DataArray | None
-        self._s = np.ndarray | None
-        self._v = xr.DataArray | None
+        self._u: xr.DataArray | None = None
+        self._s: np.ndarray | None = None
+        self._v: xr.DataArray | None = None
         self._matrix_type: str | None = None
+
+    @property
+    def n_components(self) -> int:
+        """Number of SVD components (read-only)."""
+        return self._n_components
+
+    @property
+    def s(self):
+        """Singular values (read-only)."""
+        return self._s
+
+    @property
+    def u(self):
+        """Left singular vectors (read-only)."""
+        return self._u
+
+    @property
+    def v(self):
+        """Right singular vectors (read-only)."""
+        return self._v
+
+    @property
+    def matrix_type(self):
+        """Matrix type, based on aspect radio (read-only)."""
+        return self._matrix_type
 
     def _check_matrix_type(self, X: da.Array):
         """Checks if input matrix is tall-and-skinny,

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -56,6 +56,27 @@ class TruncatedSVD:
             Rechunking will always be performed when using the 'tsqr' algorithm
             if the input array requires it, regardless of this parameter.
 
+        Attributes
+        ----------
+        u: xr.DataArray, shape (n_samples, n_components)
+            The left singular vectors. If `compute_u=True`,
+            the xarray object is numpy-backed, otherwise it's
+            dask-backed.
+        s: np.ndarray, shape (n_components,)
+            The singular vectors.
+        v: xr.DataArray, shape (n_components, n_features)
+            The right singular vectors. If `compute_v=True`,
+            the xarray object is numpy-backed, otherwise it's
+            dask-backed.
+        explained_var_ratio: np.ndarray | da.Array, shape (n_components,)
+            The ratio of explained variance by each SVD component.
+            If `compute_var_ratio=True` returned as a numpy array,
+            otherwise returned as a dask array.
+        n_components: int
+            The number of SVD components requested.
+        algorithm: str
+            The SVD algorithm requested.
+
         Notes
         -----
         The 'tsqr' algorithm is implemented via Dask's `dask.array.linalg.svd`

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -231,12 +231,18 @@ class TruncatedSVD:
         idx = 1
         if self._compute_u:
             u = computed[idx]
+            u = self._singular_vectors_to_dataarray(u, X)
             idx += 1
         if self._compute_v:
             v = computed[idx]
+            v = self._singular_vectors_to_dataarray(v, X)
             idx += 1
         if self._compute_var_ratio:
             explained_var_ratio = computed[idx]
+        self._u = u
+        self._s = s
+        self._v = v
+        self._explained_var_ratio = explained_var_ratio
 
     def transform(self, X: xr.DataArray):
         pass

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -80,6 +80,11 @@ class TruncatedSVD:
         """Whether to rechunk the input array before fitting (read-only)."""
         return self._rechunk
 
+    @property
+    def algorithm(self):
+        """SVD algorithm to use (read-only)."""
+        return self._algorithm
+
     def _check_matrix_type(self, X: da.Array):
         """Checks if input matrix is tall-and-skinny,
         short-and-fat or square/nearly-square, based on

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -29,7 +29,7 @@ class TruncatedSVD:
         self._u: xr.DataArray | da.Array | None = None
         self._s: np.ndarray | None = None
         self._v: xr.DataArray | da.Array | None = None
-        self._explained_var_ratio: float | None = None
+        self._explained_var_ratio: np.ndarray | None = None
         self._matrix_type: str | None = None
 
     @property

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -152,6 +152,7 @@ class TruncatedSVD:
         return X
 
     def _check_array(self, X: xr.DataArray):
+        """Checks if the input array is valid for SVD computation."""
         if X.ndim != 2:
             msg = (
                 "The input array must be 2-dimensional. "
@@ -210,6 +211,17 @@ class TruncatedSVD:
         X: xr.DataArray,
         **kwargs,
     ) -> None:
+        """Fit the SVD model to the input array.
+
+        Parameters
+        ----------
+        X: (xarray.DataArray), shape (n_samples, n_features)
+            The input array to fit the SVD model on.
+        **kwargs:
+            Additional keyword arguments to pass to the
+            randomized SVD algorithm. See
+            `dask.array.linalg.svd_compressed` for more details.
+        """
         if self._algorithm not in ["tsqr", "randomized"]:
             msg = (
                 f"Unsupported algorithm: {self._algorithm}. "
@@ -320,7 +332,8 @@ class TruncatedSVD:
 
         Parameters
         ----------
-        X (xarray.DataArray): the array to be transformed, which must have the same
+        X: (xarray.DataArray), shape (n_samples, n_features)
+            the array to be transformed, which must have the same
             number of features as the original array on which SVD was fitted.
 
         Returns

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -17,7 +17,6 @@ class TruncatedSVD:
         compute_v: bool = True,
         compute_var_ratio: bool = False,
         rechunk: bool = False,
-        aspect_ratio: int = 10,
     ):
         self._n_components = n_components
         self._algorithm = algorithm
@@ -25,7 +24,6 @@ class TruncatedSVD:
         self._compute_v = compute_v
         self._compute_var_ratio = compute_var_ratio
         self._rechunk = rechunk
-        self._aspect_ratio = aspect_ratio
         self._u: xr.DataArray | da.Array | None = None
         self._s: np.ndarray | None = None
         self._v: xr.DataArray | da.Array | None = None
@@ -60,11 +58,6 @@ class TruncatedSVD:
     def compute_var_ratio(self):
         """Whether to compute the ratio of explained variance (read-only)."""
         return self._compute_var_ratio
-
-    @property
-    def aspect_ratio(self):
-        """Aspect ratio used to determine matrix type (read-only)."""
-        return self._aspect_ratio
 
     @property
     def algorithm(self):

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -145,7 +145,7 @@ class TruncatedSVD:
             logger.exception(msg)
             raise TypeError(msg)
 
-    def _to_dataarray(
+    def _singular_vectors_to_dataarray(
         self, singular_vectors: np.ndarray, X: xr.DataArray
     ) -> xr.DataArray:
         """Transform the singular vectors into a Xarray DataArray following

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -1,365 +1,67 @@
-from abc import ABC, abstractmethod
-
 import dask.array as da
 import numpy as np
-from dask import persist
-from dask_ml.decomposition import TruncatedSVD as tsvd
+import xarray as xr
 
 from svdrom.logger import setup_logger
 
 logger = setup_logger("SVD", "svd.log")
 
 
-class SVD(ABC):
-    """Abstract base class for performing Singular Value Decomposition (SVD) on a
-    two-dimensional Dask array. The array is rechunked automatically for an optimized
-    SVD computation.
+class TruncatedSVD:
+    def __init__(
+        self,
+        n_components: int,
+        algorithm: str = "tsqr",
+        rechunk: bool = True,
+        aspect_ratio: int = 10,
+    ):
+        self._n_components = n_components
+        self._algorithm = algorithm
+        self._rechunk = rechunk
+        self._aspect_ratio = aspect_ratio
+        self._u = xr.DataArray | None
+        self._s = np.ndarray | None
+        self._v = xr.DataArray | None
+        self._matrix_type: str | None = None
 
-    Attributes
-    ----------
-    X (dask.array.Array): The input data matrix.
-    matrix_type (str): The type of the matrix based on its aspect ratio:
-    "tall-and-skinny", "short-and-fat" or "square".
-    n_components (int): number of SVD components
-    u (dask.array.Array): left singular vectors
-    s (numpy.ndarray): singular values
-    v (dask.array.Array): right singular vectors
-    """
-
-    def __init__(self, X: da.Array) -> None:
-        """Initializes a SVD object.
-
-        Parameters
-        ----------
-        X (dask.array.Array): The input data matrix.
-        """
-        self._n_components = 0
-        self._u = da.empty_like(0)
-        self._s = np.empty_like(0)
-        self._v = da.empty_like(0)
-        if X.ndim != 2:
-            msg = "The input array must be two-dimensional."
-            logger.exception(msg)
-            raise ValueError(msg)
-        self._X = X
-        self._matrix_type = ""
-        self._check_matrix_type()
-        self._rechunk_array()
-
-    def _check_matrix_type(self, aspect_ratio=10):
+    def _check_matrix_type(self, X: da.Array):
         """Checks if input matrix is tall-and-skinny,
         short-and-fat or square/nearly-square, based on
         the specified aspect ratio.
-
-        Parameters
-        ----------
-        aspect_ratio (int): defines the matrix type based on the
-        ratio between number of rows and columns. Defaults to 10.
         """
-        n_rows, n_cols = self._X.shape
-        if (n_rows // n_cols) >= aspect_ratio:
+        n_rows, n_cols = X.shape
+        if (n_rows // n_cols) >= self._aspect_ratio:
             self._matrix_type = "tall-and-skinny"
-        elif (n_cols // n_rows) >= aspect_ratio:
+        elif (n_cols // n_rows) >= self._aspect_ratio:
             self._matrix_type = "short-and-fat"
         else:
             self._matrix_type = "square"
 
-    def _rechunk_array(self):
+    def _rechunk_array(self, X: da.Array):
         """Rechunks the input array to ensure optimal chunk sizes
         for SVD computation based on matrix type.
         """
+        nb = X.numblocks
         msg = (
-            "Will need to rechunk the array before fitting the SVD. "
+            "Will rechunk the array before fitting the SVD. "
             "This will add some overhead."
         )
-        if (
-            self._matrix_type == "tall-and-skinny"
-            and self._X.shape[1] != self._X.chunksize[1]
-        ):
+        if self._matrix_type == "tall-and-skinny" and X.shape[1] != nb[1]:
             logger.info(msg)
-            self._X = self._X.rechunk({0: "auto", 1: -1})
-        if (
-            self._matrix_type == "short-and-fat"
-            and self._X.shape[0] != self._X.chunksize[0]
-        ):
+            return X.rechunk({0: "auto", 1: -1})
+        if self._matrix_type == "short-and-fat" and X.shape[0] != nb[0]:
             logger.info(msg)
-            self._X = self._X.rechunk({0: -1, 1: "auto"})
+            return X.rechunk({0: -1, 1: "auto"})
+        return X
 
-    @property
-    def n_components(self) -> int:
-        """Number of SVD components (read-only)."""
-        return self._n_components
-
-    @property
-    def s(self) -> np.ndarray:
-        """Singular values (read-only)."""
-        return self._s
-
-    @property
-    def u(self) -> da.Array:
-        """Left singular vectors (read-only)."""
-        return self._u
-
-    @property
-    def v(self) -> da.Array:
-        """Right singular vectors (read-only)."""
-        return self._v
-
-    @property
-    def X(self) -> da.Array:
-        """Input matrix (read-only)."""
-        return self._X
-
-    @property
-    def matrix_type(self) -> str:
-        """Matrix type, based on aspect radio (read-only)."""
-        return self._matrix_type
-
-    @abstractmethod
-    def fit(self, n_components: int, transform: bool = False, **kwargs):
-        """Perform the SVD fit operation.
-
-        Parameters
-        ----------
-        n_components (int): number of SVD components to keep.
-        transform (bool): whether to compute `u` for a tall-and-skinny
-        matrix or `v` for a short-and-fat matrix, since these can be much
-        larger than the other SVD results. Defaults to False.
-        **kwargs: keyword arguments for the underlying SVD computation.
-        """
-
-    @abstractmethod
-    def transform(
+    def fit(
         self,
+        X: xr.DataArray,
+        compute_u: bool = True,
+        compute_v: bool = True,
+        compute_var_ratio: bool = False,
     ):
-        """Compute `u` for a tall-and-skinny matrix or `v` for a
-        short-and-fat matrix if you have called `fit` with `transform=False`.
-        """
+        pass
 
-
-class ExactSVD(SVD):
-    """Performs an exact Singular Value Decomposition (SVD)
-    on a Dask array.
-
-    Inherits from the SVD base class and implements
-    Dask's exact SVD algorithm for matrices that are either
-    tall-and-skinny or short-and-fat.
-    """
-
-    def __init__(self, X):
-        super().__init__(X)
-        if self._matrix_type == "square":
-            msg = (
-                "The exact SVD algorithm can only handle tall-and-skinny "
-                "or short-and-fat matrices, i.e. the aspect ratio must be "
-                ">= 10. Try using the randomized SVD algorithm instead."
-            )
-            logger.exception(msg)
-            raise RuntimeError(msg)
-
-    def fit(self, n_components=-1, transform=False, **kwargs):
-        """The default value for `n_components` is -1, meaning
-        keep all SVD components. For additional keyword arguments,
-        see the documentation for `dask.array.linalg.svd`.
-        """
-        if n_components != -1 and (
-            not isinstance(n_components, int) or n_components <= 0
-        ):
-            msg = "n_components must be -1 or a positive integer."
-            logger.exception(msg)
-            raise ValueError(msg)
-        self._n_components = n_components
-        try:
-            logger.info("Fitting exact SVD...")
-            u, s, v = da.linalg.svd(self._X, **kwargs)
-            if self._n_components != -1:
-                u = u[:, : self._n_components]
-                s = s[: self._n_components]
-                v = v[: self._n_components, :]
-            if transform:
-                u, s, v = persist(u, s, v)
-            elif self._matrix_type == "tall-and-skinny":
-                s, v = persist(s, v)
-            elif self._matrix_type == "short-and-fat":
-                s, u = persist(s, u)
-            self._u = u
-            self._v = v
-            self._s = s.compute()
-            logger.info("Finished fitting exact SVD.")
-        except Exception as e:
-            msg = "Failed fitting exact SVD."
-            logger.exception(msg)
-            raise RuntimeError(msg) from e
-
-    def transform(self):
-        if self._n_components == 0:
-            msg = "You have to call `fit` before you can call `transform`."
-            logger.exception(msg)
-            raise RuntimeError(msg)
-        try:
-            if self._matrix_type == "tall-and-skinny":
-                self._u = self._u.persist()
-            if self._matrix_type == "short-and-fat":
-                self._v = self._v.persist()
-        except Exception as e:
-            msg = "Failed transforming input matrix."
-            logger.exception(msg)
-            raise RuntimeError(msg) from e
-
-
-class TruncatedSVD(SVD):
-    """Performs a truncated Singular Value Decomposition (SVD)
-    on a Dask array.
-
-    Inherits from the SVD base class.
-    Supports both tall-and-skinny and short-and-fat matrices,
-    but not square matrices. If the matrix is short-and-fat, it transposes
-    the matrix into a tall-and-skinny one before fitting the truncated SVD.
-    """
-
-    def __init__(self, X):
-        super().__init__(X)
-        self._decomposer = None
-        if self._matrix_type == "square":
-            msg = (
-                "The truncated SVD algorithm can only handle tall-and-skinny "
-                "or short-and-fat matrices. "
-                "For square/nearly-square matrices, try using the randomized "
-                "SVD algorithm instead."
-            )
-            logger.exception(msg)
-            raise RuntimeError(msg)
-
-    def fit(self, n_components, transform=False, **kwargs):
-        """For additional keyword arguments, see the documentation
-        for `dask_ml.decomposition.TruncatedSVD`.
-        """
-        if not isinstance(n_components, int) or n_components <= 0:
-            msg = "n_components must be a positive integer."
-            logger.exception(msg)
-            raise ValueError(msg)
-        self._n_components = n_components
-
-        logger.info("Fitting truncated SVD...")
-        self._decomposer = tsvd(
-            n_components=self._n_components, algorithm="tsqr", **kwargs
-        )
-
-        try:
-            if self._matrix_type == "tall-and-skinny":
-                logger.info("Using truncated SVD for tall-and-skinny matrix.")
-                if transform:
-                    X_transformed = self._decomposer.fit_transform(self._X)
-                    self._u = (
-                        X_transformed / self._decomposer.singular_values_
-                    )  # unscaled
-                else:
-                    self._decomposer.fit(self._X)
-                self._s = self._decomposer.singular_values_  # numpy array
-                v_np = self._decomposer.components_
-                self._v = da.from_array(v_np, chunks=v_np.shape)
-
-            elif self._matrix_type == "short-and-fat":
-                logger.info(
-                    "Using *transposed* truncated SVD for short-and-fat matrix."
-                )
-                if transform:
-                    X_transformed_t = self._decomposer.fit_transform(self._X.T)
-                    u_t = (
-                        X_transformed_t / self._decomposer.singular_values_
-                    )  # unscaled
-                    self._v = u_t.T
-                else:
-                    self._decomposer.fit(self._X.T)
-                self._s = self._decomposer.singular_values_  # numpy array
-                v_t_np = self._decomposer.components_
-                u_np = v_t_np.T
-                self._u = da.from_array(u_np, chunks=u_np.shape)
-
-            logger.info("Finished fitting truncated SVD.")
-
-        except Exception as e:
-            msg = "Failed fitting truncated SVD."
-            logger.exception(msg)
-            raise RuntimeError(msg) from e
-
-    def transform(self):
-        if self._decomposer is None:
-            msg = "You have to call `fit` before you can call `transform`."
-            logger.exception(msg)
-            raise RuntimeError(msg)
-        try:
-            if self._matrix_type == "tall-and-skinny":
-                X_transformed = self._decomposer.transform(self._X)
-                self._u = X_transformed / self._decomposer.singular_values_  # unscaled
-            if self._matrix_type == "short-and-fat":
-                X_transformed_t = self._decomposer.transform(self._X.T)
-                u_t = X_transformed_t / self._decomposer.singular_values_  # unscaled
-                self._v = u_t.T
-        except Exception as e:
-            msg = "Failed transforming input matrix."
-            logger.exception(msg)
-            raise RuntimeError(msg) from e
-
-
-class RandomizedSVD(SVD):
-    """Performs a truncated randomized Singular Value
-    Decomposition (SVD) on large matrices of any shape.
-
-    Inherits from the SVD base class.
-    Supports tall-and-skinny, short-and-fat, and square/nearly-square
-    matrices. The SVD computation is performed with
-    `dask.array.linalg.svd_compressed`.
-    """
-
-    def __init__(self, X):
-        super().__init__(X)
-
-    def fit(self, n_components, transform=False, **kwargs):
-        """Note that if the matrix is square/nearly-square, if `transform=False`
-        only the singular values and right singular vectors will be computed
-        (i.e. same behavior as a tall-and-skinny matrix).
-
-        For additional keyword arguments, see the documentation
-        for `dask.array.linalg.svd_compressed`.
-        """
-        if not isinstance(n_components, int) or n_components <= 0:
-            msg = "n_components must be a positive integer."
-            logger.exception(msg)
-            raise ValueError(msg)
-        self._n_components = n_components
-        try:
-            logger.info("Fitting randomized SVD...")
-            u, s, v = da.linalg.svd_compressed(self._X, n_components, **kwargs)
-            if transform:
-                u, s, v = persist(u, s, v)
-            elif (
-                self._matrix_type == "tall-and-skinny-matrix"
-                or self._matrix_type == "square"
-            ):
-                s, v = persist(s, v)
-            elif self._matrix_type == "short-and-fat":
-                s, u = persist(s, u)
-            self._u = u
-            self._v = v
-            self._s = s.compute()
-            logger.info("Finished fitting randomized SVD.")
-        except Exception as e:
-            msg = "Failed fitting randomized SVD."
-            logger.exception(msg)
-            raise RuntimeError(msg) from e
-
-    def transform(self):
-        if self._n_components == 0:
-            msg = "You have to call `fit` before you can call `transform`."
-            logger.exception(msg)
-            raise RuntimeError(msg)
-        try:
-            if self._matrix_type == "tall-and-skinny" or self._matrix_type == "square":
-                self._u = self._u.persist()
-            if self._matrix_type == "short-and-fat":
-                self._v = self._v.persist()
-        except Exception as e:
-            msg = "Failed transforming input matrix."
-            logger.exception(msg)
-            raise RuntimeError(msg) from e
+    def transform(self, X: xr.DataArray):
+        pass

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -115,11 +115,41 @@ class TruncatedSVD:
             return X.rechunk({0: -1, 1: "auto"})
         return X
 
+    def _check_array(self, X: xr.DataArray):
+        if X.ndim != 2:
+            msg = (
+                "The input array must be 2-dimensional. "
+                f"Got a {X.ndim}-dimensional array."
+            )
+            logger.exception(msg)
+            raise ValueError(msg)
+        if self._n_components >= X.shape[1]:
+            msg = (
+                "n_components must be less than n_features. "
+                f"Got n_components: {self.n_components}, n_features: {X.shape[1]}."
+            )
+            logger.exception(msg)
+            raise ValueError(msg)
+        if not isinstance(X.data, da.Array):
+            msg = (
+                f"The {self.__class__.__name__} class only supports Dask-backed "
+                f"Xarray DataArrays. Got {type(X.data)} instead."
+            )
+            logger.exception(msg)
+            raise TypeError(msg)
+
     def fit(
         self,
         X: xr.DataArray,
     ):
-        pass
+        self._check_array(X)
+        if self._algorithm not in ["tsqr", "randomized"]:
+            msg = (
+                f"Unsupported algorithm: {self._algorithm}. "
+                "Supported algorithms are 'tsqr' and 'randomized'."
+            )
+            logger.exception(msg)
+            raise ValueError(msg)
 
     def transform(self, X: xr.DataArray):
         pass

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -139,7 +139,7 @@ class TruncatedSVD:
             # this corresponds to `v`: replace first dimension (e.g. 'samples')
             old_dims = list(X.dims)
             new_dims = ["components", old_dims[1]]
-            coords = {k: v for k, v in X.coords.items() if k != old_dims[0]}
+            coords = {old_dims[1]: X.coords[old_dims[1]]}
             coords["components"] = np.arange(singular_vectors.shape[0])
             name = "svd_v"
         else:

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -29,6 +29,7 @@ class TruncatedSVD:
         self._u: xr.DataArray | None = None
         self._s: np.ndarray | None = None
         self._v: xr.DataArray | None = None
+        self._explained_var_ratio: float | None = None
         self._matrix_type: str | None = None
 
     @property
@@ -50,6 +51,11 @@ class TruncatedSVD:
     def v(self):
         """Right singular vectors (read-only)."""
         return self._v
+
+    @property
+    def explained_var_ratio(self):
+        """Ratio of explained variance (read-only)."""
+        return self._explained_var_ratio
 
     @property
     def matrix_type(self):

--- a/src/svdrom/svd.py
+++ b/src/svdrom/svd.py
@@ -69,9 +69,9 @@ class TruncatedSVD:
         self._compute_v = compute_v
         self._compute_var_ratio = compute_var_ratio
         self._rechunk = rechunk
-        self._u: xr.DataArray | da.Array | None = None
+        self._u: xr.DataArray | None = None
         self._s: np.ndarray | None = None
-        self._v: xr.DataArray | da.Array | None = None
+        self._v: xr.DataArray | None = None
         self._explained_var_ratio: np.ndarray | None = None
 
     @property
@@ -245,26 +245,20 @@ class TruncatedSVD:
         idx = 1
         if self._compute_u:
             u = computed[idx]
-            u = self._singular_vectors_to_dataarray(u, X)
             idx += 1
         if self._compute_v:
             v = computed[idx]
-            v = self._singular_vectors_to_dataarray(v, X)
             idx += 1
         if self._compute_var_ratio:
             explained_var_ratio = computed[idx]
-        self._u = u
+        self._u = self._singular_vectors_to_dataarray(u, X)
         self._s = s
-        self._v = v
+        self._v = self._singular_vectors_to_dataarray(v, X)
         self._explained_var_ratio = explained_var_ratio
 
-    def compute_u(self, X: xr.DataArray) -> None:
+    def compute_u(self) -> None:
         """Compute left singular vectors if they are
         still a lazy Dask collection.
-
-        Parameters
-        ----------
-        X (xarray.DataArray): the array on which the SVD was fitted.
         """
         if self._u is None:
             msg = "You must call fit() before calling compute_u()."
@@ -272,18 +266,13 @@ class TruncatedSVD:
             raise ValueError(msg)
         msg = "Computing left singular vectors..."
         logger.info(msg)
-        u = self._u.compute()
+        self._u = self._u.compute()
         msg = "Done."
         logger.info(msg)
-        self._u = self._singular_vectors_to_dataarray(u, X)
 
-    def compute_v(self, X: xr.DataArray) -> None:
+    def compute_v(self) -> None:
         """Compute right singular vectors if they are
         still a lazy Dask collection.
-
-        Parameters
-        ----------
-        X (xarray.DataArray): the array on which the SVD was fitted.
         """
         if self._v is None:
             msg = "You must call fit() before calling compute_v()."
@@ -291,10 +280,9 @@ class TruncatedSVD:
             raise ValueError(msg)
         msg = "Computing right singular vectors..."
         logger.info(msg)
-        v = self._v.compute()
+        self._v = self._v.compute()
         msg = "Done."
         logger.info(msg)
-        self._v = self._singular_vectors_to_dataarray(v, X)
 
     def transform(self, X: xr.DataArray) -> xr.DataArray:
         """Transform the input array using the computed right singular vectors.

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -165,3 +165,27 @@ def test_orthogonality(algorithm):
     assert np.allclose(
         v_ortho, identity_k, atol=1e-5
     ), "v @ v.T is not close to identity."
+
+
+@pytest.mark.parametrize("matrix_type", ["tall-and-skinny", "short-and-fat"])
+def test_transform(matrix_type):
+    """Test the transform method of TruncatedSVD."""
+    X = make_dataarray(matrix_type)
+    n_components = 10
+    tsvd = TruncatedSVD(n_components=n_components)
+    tsvd.fit(X)
+
+    X_t = tsvd.transform(X)
+    assert isinstance(
+        X_t, xr.DataArray
+    ), "Transformed data should be an xarray DataArray."
+    assert isinstance(X_t.data, np.ndarray), (
+        "Transformed data should have numpy ndarray as data, " f"got {type(X_t.data)}."
+    )
+    assert X_t.shape == (X.shape[0], n_components), (
+        f"Transformed data should have shape ({X.shape[0]}, {n_components}), "
+        f"but got {X_t.shape}."
+    )
+    assert np.allclose(
+        tsvd.u * tsvd.s, X_t, atol=1e-5
+    ), "Transformed data does not match u * s."

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -85,3 +85,15 @@ def test_basic(algorithm):
         f"Shape of explained_var_ratio should be ({n_components},), "
         f"got {tsvd.explained_var_ratio.shape}."
     )
+
+
+@pytest.mark.parametrize("matrix_type", ["tall-and-skinny", "short-and-fat", "square"])
+@pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
+def test_matrix_types(matrix_type, algorithm):
+    X = make_dataarray(matrix_type)
+    n_components = 10
+    tsvd = TruncatedSVD(
+        n_components=n_components,
+        algorithm=algorithm,
+    )
+    tsvd.fit(X)

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -144,3 +144,24 @@ def test_matrix_types(matrix_type, algorithm):
         v_coord in X_coords for v_coord in v_coords if v_coord != "components"
     ), f"v should have all coordinates from X except 'components', got {v_coords}."
     assert "components" in v_coords, "v should have 'components' coordinate."
+
+
+@pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
+def test_orthogonality(algorithm):
+    """Test orthogonality of u and v matrices."""
+    X = make_dataarray("tall-and-skinny")
+    n_components = 10
+    tsvd = TruncatedSVD(n_components=n_components, algorithm=algorithm)
+    tsvd.fit(X)
+
+    identity_k = np.eye(tsvd.n_components, dtype=np.float32)
+    u, v = tsvd.u.data, tsvd.v.data
+    u_ortho = u.T @ u
+    v_ortho = v @ v.T
+
+    assert np.allclose(
+        u_ortho, identity_k, atol=1e-5
+    ), "u.T @ u is not close to identity."
+    assert np.allclose(
+        v_ortho, identity_k, atol=1e-5
+    ), "v @ v.T is not close to identity."

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -46,6 +46,10 @@ def test_basic(algorithm):
     assert isinstance(
         tsvd.s, np.ndarray
     ), f"s should be a numpy ndarray, got {type(tsvd.s)}."
+    assert isinstance(tsvd.explained_var_ratio, np.ndarray), (
+        "explained_var_ratio should be a numpy ndarray, "
+        f"got {type(tsvd.explained_var_ratio)}."
+    )
     assert tsvd.u.shape == (
         X.shape[0],
         n_components,
@@ -57,3 +61,7 @@ def test_basic(algorithm):
     assert tsvd.s.shape == (
         n_components,
     ), f"Shape of s should be ({n_components},), got {tsvd.s.shape}."
+    assert tsvd.explained_var_ratio.shape == (n_components,), (
+        f"Shape of explained_var_ratio should be ({n_components},), "
+        f"got {tsvd.explained_var_ratio.shape}."
+    )

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -59,7 +59,6 @@ def test_basic(algorithm):
         "s",
         "v",
         "explained_var_ratio",
-        "aspect_ratio",
     )
     for attr in expected_attrs:
         assert hasattr(tsvd, attr), f"TruncatedSVD should have attribute '{attr}'."

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -10,19 +10,27 @@ def make_dataarray(matrix_type: str) -> xr.DataArray:
     if matrix_type == "tall-and-skinny":
         n_samples = 10_000
         n_features = 100
+        X = da.random.random(
+            (n_samples, n_features), chunks=(-1, int(n_features / 2))
+        ).astype("float32")
     elif matrix_type == "short-and-fat":
         n_samples = 100
         n_features = 10_000
+        X = da.random.random(
+            (n_samples, n_features), chunks=(int(n_samples / 2), -1)
+        ).astype("float32")
     elif matrix_type == "square":
         n_samples = 1_000
         n_features = 1_000
+        X = da.random.random(
+            (n_samples, n_features), chunks=(int(n_samples / 2), int(n_features / 2))
+        ).astype("float32")
     else:
         msg = (
             "Matrix type not supported. "
             "Must be one of: tall-and-skinny, short-and-fat, square."
         )
         raise ValueError(msg)
-    X = da.random.random((n_samples, n_features), chunks="auto").astype("float32")
     coords = {"samples": np.arange(n_samples), "time": np.arange(n_features)}
     dims = list(coords.keys())
     return xr.DataArray(X, dims=dims, coords=coords)
@@ -35,14 +43,12 @@ def test_basic(algorithm):
         n_components=n_components,
         algorithm=algorithm,
         compute_var_ratio=True,
-        rechunk=False,
     )
     expected_attrs = (
         "u",
         "s",
         "v",
         "explained_var_ratio",
-        "matrix_type",
         "aspect_ratio",
     )
     for attr in expected_attrs:

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -1,198 +1,59 @@
 import dask.array as da
 import numpy as np
 import pytest
+import xarray as xr
 
-from svdrom.svd import ExactSVD, RandomizedSVD, TruncatedSVD
+from svdrom.svd import TruncatedSVD
 
 
-@pytest.mark.parametrize(
-    ("matrix_type", "n_rows", "n_cols"),
-    [
-        ("tall-and-skinny", 100_000, 100),
-        ("short-and-fat", 100, 100_000),
-        ("square", 10_000, 5_000),
-    ],
-)
-class TestSVD:
-    """
-    Test suite for validating the functionality of SVD
-    (Singular Value Decomposition) implementations.
+def make_dataarray(n_rows, n_cols):
+    X = da.random.random((n_rows, n_cols), chunks="auto").astype("float32")
+    coords = {"samples": np.arange(n_rows), "time": np.arange(n_cols)}
+    dims = list(coords.keys())
+    return xr.DataArray(X, dims=dims, coords=coords)
 
-    This class provides methods to test SVD algorithms using
-    Dask arrays. It checks for correct output types, shapes,
-    and expected exceptions for different matrix types
-    (tall-and-skinny, short-and-fat or square/nearly square).
 
-    Methods
-    -------
-    _make_matrix(n_rows, n_cols)
-        Helper method to create a random Dask array of the
-        specified shape with auto chunking.
-
-    test_exact_svd(matrix_type, n_rows, n_cols)
-        Tests the ExactSVD implementation.
-        Verifies correct exception handling, output types,
-        and shapes.
-
-    test_randomized_svd(matrix_type, n_rows, n_cols)
-        Tests the RandomizedSVD implementation.
-        Checks output types and shapes for correctness.
-    """
-
+@pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
+def test_basic(algorithm):
+    n_samples = 10_000
+    n_features = 100
     n_components = 10
+    tsvd = TruncatedSVD(
+        n_components=n_components,
+        algorithm=algorithm,
+        compute_var_ratio=True,
+        rechunk=False,
+    )
+    expected_attrs = (
+        "u",
+        "s",
+        "v",
+        "explained_var_ratio",
+        "matrix_type",
+        "aspect_ratio",
+    )
+    for attr in expected_attrs:
+        assert hasattr(tsvd, attr), f"TruncatedSVD should have attribute '{attr}'."
 
-    def _make_matrix(self, n_rows, n_cols):
-        self.X = da.random.random((n_rows, n_cols), chunks="auto").astype("float32")
-
-    def test_exact_svd(self, matrix_type, n_rows, n_cols):
-        print(f"Running exact SVD test for {matrix_type} matrix.")
-        self._make_matrix(n_rows, n_cols)
-        if matrix_type == "square":
-            with pytest.raises(RuntimeError):
-                exact_svd = ExactSVD(self.X)
-        else:
-            exact_svd = ExactSVD(self.X)
-            exact_svd.fit(self.n_components, transform=True)
-
-            assert hasattr(
-                exact_svd, "u"
-            ), "The exact_svd object should have attribute 'u'."
-            assert hasattr(
-                exact_svd, "s"
-            ), "The exact_svd object should have attribute 's'."
-            assert hasattr(
-                exact_svd, "v"
-            ), "The exact_svd object should have attribute 'v'."
-            assert hasattr(
-                exact_svd, "n_components"
-            ), "The exact_svd object should have attribute 'n_components'."
-
-            u, s, v = exact_svd.u, exact_svd.s, exact_svd.v
-            assert isinstance(
-                u, da.Array
-            ), f"The u matrix should be of type dask.array.Array, not {type(u)}."
-            assert isinstance(
-                v, da.Array
-            ), f"The v matrix should be of type dask.array.Array, not {type(v)}."
-            assert isinstance(
-                s, np.ndarray
-            ), f"The s vector should be of type numpy.ndarray, not {type(s)}."
-            assert u.shape == (
-                n_rows,
-                self.n_components,
-            ), "The u matrix should have shape (n_samples, n_components)."
-            assert v.shape == (
-                self.n_components,
-                n_cols,
-            ), "The v matrix should have shape (n_components, n_features)."
-            assert s.shape == (
-                self.n_components,
-            ), "The s vector should have shape (n_components,)."
-
-    def test_randomized_svd(self, matrix_type, n_rows, n_cols):
-        print(f"Running randomized SVD test for {matrix_type} matrix.")
-        self._make_matrix(n_rows, n_cols)
-        randomized_svd = RandomizedSVD(self.X)
-        randomized_svd.fit(self.n_components, transform=True)
-
-        assert hasattr(
-            randomized_svd, "u"
-        ), "The randomized_svd object should have attribute 'u'."
-        assert hasattr(
-            randomized_svd, "s"
-        ), "The randomized_svd object should have attribute 's'."
-        assert hasattr(
-            randomized_svd, "v"
-        ), "The randomized_svd object should have attribute 'v'."
-        assert hasattr(
-            randomized_svd, "n_components"
-        ), "The randomized_svd object should have attribute 'n_components'."
-
-        u, s, v = randomized_svd.u, randomized_svd.s, randomized_svd.v
-        assert isinstance(
-            u, da.Array
-        ), f"The u matrix should be of type dask.array.Array, not {type(u)}."
-        assert isinstance(
-            v, da.Array
-        ), f"The v matrix should be of type dask.array.Array, not {type(v)}."
-        assert isinstance(
-            s, np.ndarray
-        ), f"The s vector should be of type numpy.ndarray, not {type(s)}."
-        assert u.shape == (
-            n_rows,
-            self.n_components,
-        ), (
-            f"The u matrix should have shape ({n_rows}, {self.n_components}), "
-            f"but got {u.shape}."
-        )
-        assert v.shape == (
-            self.n_components,
-            n_cols,
-        ), (
-            f"The v matrix should have shape ({self.n_components}, {n_cols}), "
-            f"but got {v.shape}."
-        )
-        assert s.shape == (
-            self.n_components,
-        ), f"The s vector should have shape ({self.n_components},), but got {s.shape}."
-
-    def test_truncated_svd(self, matrix_type, n_rows, n_cols):
-        print(f"Running truncated SVD test for {matrix_type} matrix.")
-        self._make_matrix(n_rows, n_cols)
-
-        if matrix_type == "square":
-            with pytest.raises(RuntimeError):
-                TruncatedSVD(self.X)
-        else:
-            truncated_svd = TruncatedSVD(self.X)
-            truncated_svd.fit(n_components=self.n_components, transform=True)
-
-            assert hasattr(
-                truncated_svd, "u"
-            ), "The truncated_svd object should have attribute 'u'."
-            assert hasattr(
-                truncated_svd, "s"
-            ), "The truncated_svd object should have attribute 's'."
-            assert hasattr(
-                truncated_svd, "v"
-            ), "The truncated_svd object should have attribute 'v'."
-            assert hasattr(
-                truncated_svd, "n_components"
-            ), "The truncated_svd object should have attribute 'n_components'."
-
-            u, s, v = truncated_svd.u, truncated_svd.s, truncated_svd.v
-
-            assert isinstance(
-                u, da.Array
-            ), f"The u matrix should be of type dask.array.Array, not {type(u)}."
-            assert isinstance(
-                s, np.ndarray
-            ), f"The s vector should be of type numpy.ndarray, not {type(s)}."
-            assert isinstance(
-                v, da.Array
-            ), f"The v matrix should be of type dask.array.Array, not {type(v)}."
-
-            assert u.shape == (n_rows, self.n_components), (
-                f"The u matrix should have shape ({n_rows}, {self.n_components}), "
-                f"but got {u.shape}."
-            )
-            assert s.shape == (self.n_components,), (
-                f"The s vector should have shape ({self.n_components},), "
-                f"but got {s.shape}."
-            )
-            assert v.shape == (self.n_components, n_cols), (
-                f"The v matrix should have shape ({self.n_components}, {n_cols}), "
-                f"but got {v.shape}."
-            )
-
-            # check orthogonality
-            identity_k = np.eye(self.n_components, dtype=np.float32)
-            u_ortho = (u.T @ u).compute()
-            v_ortho = (v @ v.T).compute()
-
-            assert np.allclose(
-                u_ortho, identity_k, atol=1e-5
-            ), "u.T @ u is not close to identity."
-            assert np.allclose(
-                v_ortho, identity_k, atol=1e-5
-            ), "v @ v.T is not close to identity."
+    X = make_dataarray(n_samples, n_features)
+    tsvd.fit(X)
+    assert isinstance(
+        tsvd.u, xr.DataArray
+    ), f"u should be an xarray DataArray, got {type(tsvd.u)}."
+    assert isinstance(
+        tsvd.v, xr.DataArray
+    ), f"v should be an xarray DataArray, got {type(tsvd.v)}."
+    assert isinstance(
+        tsvd.s, np.ndarray
+    ), f"s should be a numpy ndarray, got {type(tsvd.s)}."
+    assert tsvd.u.shape == (
+        X.shape[0],
+        n_components,
+    ), f"Shape of u should be ({n_samples}, {n_components}), got {tsvd.u.shape}."
+    assert tsvd.v.shape == (
+        n_components,
+        X.shape[1],
+    ), f"Shape of v should be ({n_components}, {n_features}), got {tsvd.v.shape}."
+    assert tsvd.s.shape == (
+        n_components,
+    ), f"Shape of s should be ({n_components},), got {tsvd.s.shape}."

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -7,6 +7,15 @@ from svdrom.svd import TruncatedSVD
 
 
 def make_dataarray(matrix_type: str) -> xr.DataArray:
+    """Make a Dask-backed DataArray with random data of
+    specified matrix type. The matrix type can be one of:
+    - "tall-and-skinny": More samples than features.
+    - "short-and-fat": More features than samples.
+    - "square": Equal number of samples and features.
+
+    Chunks are set to test that the TruncatedSVD can handle
+    them correctly.
+    """
     if matrix_type == "tall-and-skinny":
         n_samples = 10_000
         n_features = 100
@@ -38,6 +47,7 @@ def make_dataarray(matrix_type: str) -> xr.DataArray:
 
 @pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
 def test_basic(algorithm):
+    """Test basic functionality of TruncatedSVD."""
     n_components = 10
     tsvd = TruncatedSVD(
         n_components=n_components,
@@ -88,6 +98,7 @@ def test_basic(algorithm):
 @pytest.mark.parametrize("matrix_type", ["tall-and-skinny", "short-and-fat", "square"])
 @pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
 def test_matrix_types(matrix_type, algorithm):
+    """Test TruncatedSVD with different matrix shapes."""
     X = make_dataarray(matrix_type)
     n_samples, n_features = X.shape
     n_components = 10


### PR DESCRIPTION
This PR refactors the SVD implementation to a single `TruncatedSVD` class, allowing to choose between the 'tsqr' and 'randomized' algorithms. The implementation follows the design of [Dask-ML's TruncatedSVD](https://github.com/dask/dask-ml/blob/main/dask_ml/decomposition/truncated_svd.py), but here we support Xarray objects instead of bare Dask Arrays.

The updated files are:
* `src/svdrom/svd.py`
* `tests/test_svd.py`

Closes #14.
Closes #15.